### PR TITLE
depends_onを追加して、stageの作成をエラーにさせない

### DIFF
--- a/snowflake/main.tf
+++ b/snowflake/main.tf
@@ -8,4 +8,5 @@ resource "snowflake_stage" "preset_stage" {
   database    = "INTERN_${local.name}_DB"
   schema      = "PUBLIC"
   storage_integration = "S3_INT"
+  depends_on = [ snowflake_database.preset_db ]
 }


### PR DESCRIPTION
apply時に、元のDBがないことによってstage追加エラーになる

depends_onを入れて、DBの作成を待つようにする

```
╷
│ Error: error creating stage INTERN_040_STAGE, err: 002003 (02000): SQL compilation error:
│ Database 'INTERN_040_DB' does not exist or not authorized.
│
│   with snowflake_stage.preset_stage,
│   on main.tf line 5, in resource "snowflake_stage" "preset_stage":
│    5: resource "snowflake_stage" "preset_stage" {
│
╵
```